### PR TITLE
Join persistent log into state machine trait

### DIFF
--- a/schema/messages.capnp
+++ b/schema/messages.capnp
@@ -9,13 +9,19 @@ struct Entry {
     term @0 :UInt64;
     union {
         noop @1 :Void;
-        proposal @2 :Data;
+        proposal @2 :ProposalEntry;
         config @3 :ConfigChangeEntry;
     }
+    
+    struct ProposalEntry {
+        data @0 :Data;
+        clientId @1 :UInt64;
+    } 
 
     struct ConfigChangeEntry {
         peers @0 :List(Peer);
         isActual @1 :Bool;
+        admidId @2 :UInt64;
     }
 }
 
@@ -115,6 +121,20 @@ struct ClientMessage {
 
         clientQueryRequest @2 :Data;
         clientQueryResponse @3 :ClientResponse;
+    }
+
+    struct ClientRequest {
+        data @0 :Data;
+        guarantee @1 :ClientGuarantee;
+    }
+
+    struct ClientGuarantee {
+        union {
+            instant @0 :Void;
+            fast @1 :Void;
+            log @2 :Void;
+            batch @3 :Void;
+        }
     }
 
     struct ClientResponse {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 use crate::error::Error;
 use crate::message::Timeout;
 
-use crate::{LogIndex, Peer, ServerId, Term};
+use crate::{Peer, ServerId};
 
 pub use crate::handler::Handler;
 pub use crate::persistent_log::Log;
@@ -87,10 +87,12 @@ impl ConsensusConfig {
     }
 }
 
+/// Tunables for each node. This config is per node and not replicated.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct StateOptions {
+pub struct ConsensusOptions {
     pub timeouts: SlowNodeTimeouts,
 }
+
 
 /// Raft paper describes a multiple-round method for catching up the log where the size of the
 /// message is reduced each round due to number of log entries decreasing.
@@ -108,10 +110,10 @@ pub struct StateOptions {
 /// timeouts are given per message, i.e. per snapshot chunk or a list of log entries,
 /// each timeout is given as a number of election timeouts, so it is a bit random
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SlowNodeTimeouts {
-    pub(crate) max_snapshot_timeouts: u32,
-    pub(crate) max_log_timeouts: u32,
-    pub(crate) max_total_timeouts: u32,
+pub struct SlowNodeTimeouts {
+    pub max_snapshot_timeouts: u32,
+    pub max_log_timeouts: u32,
+    pub max_total_timeouts: u32,
 }
 
 impl Default for SlowNodeTimeouts {

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,6 +89,12 @@ pub enum CriticalError {
     #[error("BUG: leader's log could not find term for index {} at {}", _0, _1)]
     LeaderLogBroken(LogIndex, &'static str),
 
+    #[error("BUG: entry kind does not match entry data at at {}", _0)]
+    LogInconsistentEntry(LogIndex),
+
+    #[error("BUG: log returned existing voted_for in a solitary consensus: {}", _0)]
+    LogInconsistentVoted(ServerId),
+
     #[error("Consensus state become unrecoverable after last error, consensus cannot proceed")]
     Unrecoverable,
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -22,6 +22,7 @@ pub trait Handler: Debug {
     /// exchanged messages witht hem.
     // Called when some follower(especially the catching one) receives the latest configuration change
     // so peer list may be counted updated and ready for sending messages.
+    // FIXME: insert calls into places where consensus config changes
     fn update_peers(&mut self, peers: &ConsensusConfig);
 
     #[allow(unused_variables)]

--- a/src/message/common.rs
+++ b/src/message/common.rs
@@ -47,6 +47,8 @@ pub enum Timeout {
     Election,
     /// A heartbeat timeout. Stable value, set by leader separately for each peer.
     Heartbeat(ServerId),
+    /// A client timeout, if time based client message batching is enabled
+    Client,
 }
 
 // TODO

--- a/src/persistent_log/mod.rs
+++ b/src/persistent_log/mod.rs
@@ -14,6 +14,7 @@
 //pub mod fs;
 pub mod mem;
 
+use crate::message::ClientGuarantee;
 // FIXME:
 //pub use persistent_log::fs::FsLog;
 pub use crate::persistent_log::mem::MemLog;
@@ -24,7 +25,7 @@ use std::fmt::Debug;
 use crate::config::ConsensusConfig;
 use crate::error::Error;
 use crate::message::peer::{Entry, EntryData};
-use crate::{LogIndex, ServerId, Term};
+use crate::{AdminId, ClientId, LogIndex, ServerId, Term};
 
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Serialize};
@@ -32,64 +33,81 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 
 /// A layer of persistence to store Raft log and state data.
-/// Should implement general-purpose log storage for appending raft log entries
-/// along with storing iseveral specific values, like voted_for, current cluster configuration
-// TODO store or a list of registered clients?
+/// Should implement a log storage for appending raft log entries
+/// along with storing iseveral specific values, like voted_for, current cluster configuration.
+///
+/// The implementor is responsible for keeping ordering and leaving no gaps in log.
+///
+/// For example when batching is used, the entries may not be persisted right away. In that case,
+/// latest_log_index should not forward to a new value until the corresponsing entries
+/// are synced to disk.
+///
+/// The latter automatically means, that the tradeoff between cluster stability
+/// and probable performance benefits lays on the implementor.
+/// Since Raft always counts on entries persisted to the log, it does not manage the
+/// indexes of the "tail"(i.e. just appended) entries. If implementation wants
+/// to guarantee the persistence of these entries, it should not return from
+/// the function until the entries are synced properly.
+///
+/// Log indexes in Raft start with 1 (0 is reserved as special).
 pub trait Log {
     type Error: std::error::Error + Sized + 'static;
 
-    //  Logging related persistent functions
+    /// Should return the index of the latest log entry ever appended to log. To avoid data losses
+    /// this index should point the data that is guaranteed to be persisted.
+    /// Should return LogIndex(0) if the log is empty.
+    fn latest_index(&self) -> Result<LogIndex, Self::Error>;
+    fn latest_persisted_index(&self) -> Result<LogIndex, Self::Error>;
 
-    /// Should return the index of the latest persisted log entry (0 if the log is empty).
-    fn latest_log_index(&self) -> Result<LogIndex, Self::Error>;
-
-    /// Should return the index of the first persisted log entry (0 if the log is empty).
+    /// Should return the index of the first log entry (0 if the log is empty).
     fn first_log_index(&self) -> Result<LogIndex, Self::Error>;
 
     /// Should return term corresponding to log index if such term and index exists in log
-    /// Shoult NOT return an error on non-existence
+    /// Shoult NOT return an error on non-existence.
     fn term_of(&self, index: LogIndex) -> Result<Option<Term>, Self::Error>;
 
-    /// Delete or mark invalid all entries since specified log index
-    /// return the new index. It is allowed to return any index lower than requested
+    /// Delete or mark as invalid all entries since specified log index
+    /// return the new index. It is allowed to return any index lower than requested.
     fn discard_since(&mut self, index: LogIndex) -> Result<LogIndex, Self::Error>;
 
     /// Should discard all entries until specified index (including the entry at `index`).
     /// Should return the new first index, index should be less or equal to the requested
     fn discard_until(&self, index: LogIndex) -> Result<LogIndex, Self::Error>;
 
-    /// Reads the entry at the provided log index into an entry provided by reference
+    /// Should reads the entry at the provided log index into an entry provided by reference.
+    /// Consensus guarantees that no entries at indexes higher than latest_log_index will be read.
+    /// The entry metadata should also be persisted, but it is recommended to store it in the memory because
+    /// it is highly likely to be requested soon.
     fn read_entry(&self, index: LogIndex, dest: &mut LogEntry) -> Result<(), Self::Error>;
 
-    /// Must append an entry to the log. If the index in the log is earlier, than requested,
-    /// the log must be truncated so the added entry always being the last one, with no gaps.
-    /// Is not required for this function to save a config entries, if any pass by. This will be
-    /// done separately to make sure only committed configuration is persisted.
-    /// The caller(i.e. the consensus) will check for the gaps, so they should not actually happen.
-    /// NOTE: log indexes in Raft start with 1 (0 is reserved as special), this function should consider this
-    fn append_entry<'a>(
-        &mut self,
-        at: LogIndex,
-        entry: &LogEntryRef<'a>,
-    ) -> Result<(), Self::Error>;
+    /// Should return the metadata of the entry at the specified index. No indexes higher
+    /// than latest_log_index will be requested.
+    fn entry_meta_at(&self, index: LogIndex) -> Result<LogEntryMeta, Self::Error>;
 
-    /// Returns the latest known term.
+    /// Must append an entry to the log. The sync and index shifting should be decided by implementation, but
+    /// kept with no gaps and incoming ordering.
+    /// This function should persist configuration change entries, but MUST not instantly used from
+    /// last_config_* functions. This will be done separately only when configuration is committed.
+    fn append_entries(&mut self, start: LogIndex, entries: &[LogEntry]) -> Result<(), Self::Error>;
+
+    /// Should return the latest known term.
     fn current_term(&self) -> Result<Term, Self::Error>;
 
-    /// Sets the current term to the provided value. The provided term must be greater than
-    /// the current term.
+    /// Should sets the current term to the provided value. The provided term must be greater than
+    /// the current term. Recommended to be synchronous, delays in persisting term may break the
+    /// consensus.
     fn set_current_term(&mut self, term: Term) -> Result<(), Self::Error>;
 
-    // Voting related persistence
-    /// Returns the candidate id of the candidate voted for in the current term (or none).
+    /// Returns the id of the candidate node voted for in the current term, if any.
     fn voted_for(&self) -> Result<Option<ServerId>, Self::Error>;
 
-    /// Sets the candidate id the node voted for in the current term.
-    /// None means voted_for should be unset
+    /// Should save a provided candidate id the node voted for the current term.
+    /// None means voted_for should be unset(i.e. cleared)
     fn set_voted_for(&mut self, server: Option<ServerId>) -> Result<(), Self::Error>;
 
-    // Config pesistence
     /// Should persist the provided configuration and it's index for later retrieval.
+    /// Recommended to be synchronous, delays in persisting may break the
+    /// consensus.
     fn set_latest_config(
         &mut self,
         config: &ConsensusConfig,
@@ -111,13 +129,22 @@ pub struct LogEntry {
     pub data: LogEntryData,
 }
 
+/// Kinds of a log entry without internal data
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+pub enum LogEntryMeta {
+    Empty,
+    Proposal(ClientId, ClientGuarantee),
+    Config(ConsensusConfig, AdminId),
+}
+
 /// Kinds of a log entry to be processed
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub enum LogEntryData {
     Empty,
-    Proposal(Vec<u8>),
-    Config(ConsensusConfig),
+    Proposal(Vec<u8>, ClientId, ClientGuarantee),
+    Config(ConsensusConfig, AdminId),
 }
 
 impl LogEntry {
@@ -126,9 +153,21 @@ impl LogEntry {
             term: self.term,
             data: match self.data {
                 LogEntryData::Empty => LogEntryDataRef::Empty,
-                LogEntryData::Proposal(ref v) => LogEntryDataRef::Proposal(v.as_slice()),
-                LogEntryData::Config(ref c) => LogEntryDataRef::Config(c),
+                LogEntryData::Proposal(ref v, client, guarantee) => {
+                    LogEntryDataRef::Proposal(v.as_slice(), client, guarantee)
+                }
+                LogEntryData::Config(ref c, admin) => LogEntryDataRef::Config(c, admin),
             },
+        }
+    }
+
+    pub fn meta(&self) -> LogEntryMeta {
+        match &self.data {
+            LogEntryData::Empty => LogEntryMeta::Empty,
+            LogEntryData::Proposal(_, client, guarantee) => {
+                LogEntryMeta::Proposal(*client, *guarantee)
+            }
+            LogEntryData::Config(config, admin) => LogEntryMeta::Config(config.clone(), *admin),
         }
     }
 }
@@ -148,8 +187,11 @@ impl From<LogEntry> for Entry {
             term: e.term,
             data: match e.data {
                 LogEntryData::Empty => EntryData::Noop,
-                LogEntryData::Proposal(proposal) => EntryData::Proposal(proposal),
-                LogEntryData::Config(c) => EntryData::Config(c, false),
+                LogEntryData::Proposal(proposal, client, _) => {
+                    // no need to replicate a guarantee
+                    EntryData::Proposal(proposal, client)
+                }
+                LogEntryData::Config(c, admin) => EntryData::Config(c, false, admin),
             },
         }
     }
@@ -163,22 +205,27 @@ impl LogEntry {
         }
     }
 
-    pub fn new_proposal(term: Term, data: Vec<u8>) -> Self {
+    pub fn new_proposal(
+        term: Term,
+        data: Vec<u8>,
+        client: ClientId,
+        guarantee: ClientGuarantee,
+    ) -> Self {
         Self {
             term,
-            data: LogEntryData::Proposal(data),
+            data: LogEntryData::Proposal(data, client, guarantee),
         }
     }
 
-    pub fn new_config(term: Term, config: ConsensusConfig) -> Self {
+    pub fn new_config(term: Term, config: ConsensusConfig, admin: AdminId) -> Self {
         Self {
             term,
-            data: LogEntryData::Config(config),
+            data: LogEntryData::Config(config, admin),
         }
     }
 }
 
-/// The record to be added into log
+/// The reference to a record to be added into log
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogEntryRef<'a> {
     pub term: Term,
@@ -189,8 +236,8 @@ pub struct LogEntryRef<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LogEntryDataRef<'a> {
     Empty,
-    Proposal(&'a [u8]),
-    Config(&'a ConsensusConfig),
+    Proposal(&'a [u8], ClientId, ClientGuarantee),
+    Config(&'a ConsensusConfig, AdminId),
 }
 
 impl<'a> From<LogEntryRef<'a>> for LogEntry {
@@ -199,8 +246,10 @@ impl<'a> From<LogEntryRef<'a>> for LogEntry {
             term: e.term,
             data: match e.data {
                 LogEntryDataRef::Empty => LogEntryData::Empty,
-                LogEntryDataRef::Proposal(proposal) => LogEntryData::Proposal(proposal.to_vec()),
-                LogEntryDataRef::Config(c) => LogEntryData::Config(c.clone()),
+                LogEntryDataRef::Proposal(proposal, client, guarantee) => {
+                    LogEntryData::Proposal(proposal.to_vec(), client, guarantee)
+                }
+                LogEntryDataRef::Config(c, admin) => LogEntryData::Config(c.clone(), admin),
             },
         }
     }
@@ -212,8 +261,10 @@ impl<'a> From<&'a LogEntryRef<'a>> for LogEntry {
             term: e.term,
             data: match e.data {
                 LogEntryDataRef::Empty => LogEntryData::Empty,
-                LogEntryDataRef::Proposal(proposal) => LogEntryData::Proposal(proposal.to_vec()),
-                LogEntryDataRef::Config(c) => LogEntryData::Config(c.clone()),
+                LogEntryDataRef::Proposal(proposal, client, guarantee) => {
+                    LogEntryData::Proposal(proposal.to_vec(), client, guarantee)
+                }
+                LogEntryDataRef::Config(c, admin) => LogEntryData::Config(c.clone(), admin),
             },
         }
     }
@@ -225,8 +276,10 @@ impl<'a> From<LogEntryRef<'a>> for Entry {
             term: e.term,
             data: match e.data {
                 LogEntryDataRef::Empty => EntryData::Noop,
-                LogEntryDataRef::Proposal(proposal) => EntryData::Proposal(proposal.to_vec()),
-                LogEntryDataRef::Config(c) => EntryData::Config(c.clone(), false),
+                LogEntryDataRef::Proposal(proposal, client, _) => {
+                    EntryData::Proposal(proposal.to_vec(), client)
+                }
+                LogEntryDataRef::Config(c, admin) => EntryData::Config(c.clone(), false, admin),
             },
         }
     }
@@ -238,8 +291,10 @@ impl<'a> From<&'a LogEntryRef<'a>> for Entry {
             term: e.term,
             data: match e.data {
                 LogEntryDataRef::Empty => EntryData::Noop,
-                LogEntryDataRef::Proposal(proposal) => EntryData::Proposal(proposal.to_vec()),
-                LogEntryDataRef::Config(c) => EntryData::Config(c.clone(), false),
+                LogEntryDataRef::Proposal(proposal, client, _) => {
+                    EntryData::Proposal(proposal.to_vec(), client)
+                }
+                LogEntryDataRef::Config(c, admin) => EntryData::Config(c.clone(), false, admin),
             },
         }
     }
@@ -258,26 +313,10 @@ pub enum LogError {
 }
 
 //#[cfg(test)]
-//use std::io::Cursor;
 
-//#[cfg(test)]
-//// helper for easier test migration
-//pub(crate) fn append_entries<L: Log>(
-//store: &mut L,
-//from: LogIndex,
-//entries: &[(Term, EntryKind, &[u8])],
-//) -> Result<(), L::Error> {
-//let entries = entries
-//.iter()
-//.map(|&(term, kind, entry)| (term, kind, Cursor::new(entry)));
-//store.append_entries(from, entries)?;
-//Ok(())
-//}
-
-//#[cfg(test)]
-//// helper for easier test migration
-//pub(crate) fn get_entry<L: Log>(store: &L, log_index: LogIndex) -> (Term, EntryKind, Vec<u8>) {
-//let mut data = Vec::new();
-//let term = store.entry(log_index, Some(&mut data)).unwrap();
-//(term, kind, data)
-//}
+// TODO: Test logs:
+// * persists everything as expected
+// * if log is non-volatile, persistence does not break on restarts
+// * no gaps, keeps ordering
+// * discards as requested
+// * appended config change entries are not actualized in latest_config_*

--- a/src/state_impl.rs
+++ b/src/state_impl.rs
@@ -2,21 +2,20 @@ use crate::{error::Error, AdminId};
 
 use crate::handler::Handler;
 use crate::message::*;
-use crate::persistent_log::Log;
+
 use crate::state_machine::StateMachine;
 use crate::{ClientId, ServerId};
 
 use crate::raft::CurrentState;
 
 /// Applies a peer message to the consensus
-pub(crate) fn apply_peer_message<L, M, S: StateImpl<L, M, H>, H: Handler>(
+pub(crate) fn apply_peer_message<M, S: StateImpl<M, H>, H: Handler>(
     s: S,
     handler: &mut H,
     from: ServerId,
     message: &PeerMessage,
-) -> Result<CurrentState<L, M, H>, Error>
+) -> Result<CurrentState<M, H>, Error>
 where
-    L: Log,
     M: StateMachine,
     H: Handler,
 {
@@ -65,13 +64,12 @@ where
     }
 }
 
-pub(crate) fn apply_timeout<L, M, S: StateImpl<L, M, H>, H: Handler>(
+pub(crate) fn apply_timeout<M, S: StateImpl<M, H>, H: Handler>(
     mut s: S,
     handler: &mut H,
     timeout: Timeout,
-) -> Result<CurrentState<L, M, H>, Error>
+) -> Result<CurrentState<M, H>, Error>
 where
-    L: Log,
     M: StateMachine,
     H: Handler,
 {
@@ -83,18 +81,21 @@ where
             handler.send_peer_message(id, request);
             Ok(s.into_consensus_state())
         }
+        Timeout::Client => {
+            s.client_timeout(handler)?;
+            Ok(s.into_consensus_state())
+        }
     }
 }
 
 /// Applies a client message to the consensus state machine.
-pub(crate) fn apply_client_message<L, M, S: StateImpl<L, M, H>, H: Handler>(
+pub(crate) fn apply_client_message<M, S: StateImpl<M, H>, H: Handler>(
     s: &mut S,
     handler: &mut H,
     from: ClientId,
     message: &ClientMessage,
 ) -> Result<(), Error>
 where
-    L: Log,
     M: StateMachine,
     H: Handler,
 {
@@ -120,20 +121,19 @@ where
     }
 }
 
-pub(crate) fn apply_admin_message<L, M, S: StateImpl<L, M, H>, H: Handler>(
+pub(crate) fn apply_admin_message<M, S: StateImpl<M, H>, H: Handler>(
     s: &mut S,
     handler: &mut H,
     from: AdminId,
     message: &AdminMessage,
 ) -> Result<(), Error>
 where
-    L: Log,
     M: StateMachine,
     H: Handler,
 {
     match message {
         AdminMessage::AddServerRequest(request) => {
-            let message = s.add_server_request(handler, request)?;
+            let message = s.add_server_request(handler, from, request)?;
             handler.send_admin_message(from, AdminMessage::AddServerResponse(message));
             Ok(())
         }
@@ -168,9 +168,8 @@ where
 }
 
 /// This trait defines a consensus behaviour that should be supported in each particular state
-pub(crate) trait StateImpl<L, M, H>
+pub(crate) trait StateImpl<M, H>
 where
-    L: Log,
     M: StateMachine,
     H: Handler,
 {
@@ -182,7 +181,7 @@ where
         handler: &mut H,
         from: ServerId,
         request: &AppendEntriesRequest,
-    ) -> Result<(AppendEntriesResponse, CurrentState<L, M, H>), Error>;
+    ) -> Result<(AppendEntriesResponse, CurrentState<M, H>), Error>;
 
     /// Apply an append entries response to the consensus.
     fn append_entries_response(
@@ -190,7 +189,7 @@ where
         handler: &mut H,
         from: ServerId,
         response: &AppendEntriesResponse,
-    ) -> Result<(Option<PeerMessage>, CurrentState<L, M, H>), Error>;
+    ) -> Result<(Option<PeerMessage>, CurrentState<M, H>), Error>;
 
     ///////////////////////////
     // RequestVoteRPC
@@ -200,7 +199,7 @@ where
         handler: &mut H,
         candidate: ServerId,
         request: &RequestVoteRequest,
-    ) -> Result<(Option<RequestVoteResponse>, CurrentState<L, M, H>), Error>;
+    ) -> Result<(Option<RequestVoteResponse>, CurrentState<M, H>), Error>;
 
     /// Applies a request vote response to the consensus.
     fn request_vote_response(
@@ -208,10 +207,10 @@ where
         handler: &mut H,
         from: ServerId,
         response: &RequestVoteResponse,
-    ) -> Result<CurrentState<L, M, H>, Error>;
+    ) -> Result<CurrentState<M, H>, Error>;
 
-    /// Applies a preliminary timeout response to the consensus
-    fn timeout_now(self, handler: &mut H) -> Result<CurrentState<L, M, H>, Error>;
+    /// Applies a preliminary election timeout response to the consensus
+    fn timeout_now(self, handler: &mut H) -> Result<CurrentState<M, H>, Error>;
 
     /// Apply an append entries request to the consensus state machine.
     fn install_snapshot_request(
@@ -219,7 +218,7 @@ where
         handler: &mut H,
         from: ServerId,
         request: &InstallSnapshotRequest,
-    ) -> Result<(PeerMessage, CurrentState<L, M, H>), Error>;
+    ) -> Result<(PeerMessage, CurrentState<M, H>), Error>;
 
     /// Apply an append entries response to the consensus.
     fn install_snapshot_response(
@@ -227,7 +226,7 @@ where
         handler: &mut H,
         from: ServerId,
         response: &InstallSnapshotResponse,
-    ) -> Result<(Option<PeerMessage>, CurrentState<L, M, H>), Error>;
+    ) -> Result<(Option<PeerMessage>, CurrentState<M, H>), Error>;
 
     ///////////////////////////
     // Timeouts
@@ -235,7 +234,12 @@ where
 
     /// Handles heartbeat timeout event
     fn heartbeat_timeout(&mut self, peer: ServerId) -> Result<AppendEntriesRequest, Error>;
-    fn election_timeout(self, handler: &mut H) -> Result<CurrentState<L, M, H>, Error>;
+
+    /// Handles election timeout
+    fn election_timeout(self, handler: &mut H) -> Result<CurrentState<M, H>, Error>;
+
+    /// Handles client requests timeout if batching is enabled
+    fn client_timeout(&mut self, handler: &mut H) -> Result<(), Error>;
 
     fn check_compaction(&mut self, handler: &mut H, force: bool) -> Result<bool, Error>;
     ///////////////////////////
@@ -266,6 +270,7 @@ where
     fn add_server_request(
         &mut self,
         handler: &mut H,
+        from: AdminId,
         request: &AddServerRequest,
     ) -> Result<ConfigurationChangeResponse, Error>;
 
@@ -285,5 +290,5 @@ where
     // Utility messages and actions
     fn peer_connected(&mut self, handler: &mut H, peer: ServerId) -> Result<(), Error>;
 
-    fn into_consensus_state(self) -> CurrentState<L, M, H>;
+    fn into_consensus_state(self) -> CurrentState<M, H>;
 }

--- a/src/state_machine/null.rs
+++ b/src/state_machine/null.rs
@@ -1,13 +1,18 @@
+use std::marker::PhantomData;
+
 use thiserror::Error as ThisError;
 
+use crate::persistent_log::Log;
 use crate::{state_machine::StateMachine, LogIndex};
 
 use super::SnapshotInfo;
 
 /// A state machine with no states.
+/// Always replies to queries with existing, but empty answer.
 #[derive(Debug)]
-pub struct NullStateMachine {
-    snapshot_index: LogIndex,
+pub struct NullStateMachine<L: Log> {
+    index: LogIndex,
+    _pd: PhantomData<L>,
 }
 
 #[derive(ThisError, Debug)]
@@ -16,19 +21,22 @@ pub enum Error {
     NullMachineError,
 }
 
-impl NullStateMachine {
+impl<L: Log> NullStateMachine<L> {
     pub fn new() -> Self {
         Self {
-            snapshot_index: LogIndex(0),
+            index: LogIndex(0),
+            _pd: PhantomData,
         }
     }
 }
 
-impl StateMachine for NullStateMachine {
+impl<L: Log> StateMachine for NullStateMachine<L> {
+    type Log = L;
     type Error = Error;
 
-    fn apply(&mut self, _command: &[u8], _: bool) -> Result<Vec<u8>, Self::Error> {
-        Ok(Vec::new())
+    fn apply(&mut self, index: LogIndex, _: bool) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.index = index;
+        Ok(Some(Vec::new()))
     }
 
     fn query(&self, _query: &[u8]) -> Result<Vec<u8>, Self::Error> {
@@ -36,9 +44,9 @@ impl StateMachine for NullStateMachine {
     }
 
     fn snapshot_info(&self) -> Result<Option<SnapshotInfo>, Self::Error> {
-        if self.snapshot_index != LogIndex(0) {
+        if self.index != LogIndex(0) {
             Ok(Some(SnapshotInfo {
-                index: self.snapshot_index,
+                index: self.index,
                 size: 0,
             }))
         } else {
@@ -47,12 +55,12 @@ impl StateMachine for NullStateMachine {
     }
 
     fn take_snapshot(&mut self, index: LogIndex) -> Result<(), Self::Error> {
-        self.snapshot_index = index;
+        self.index = index;
         Ok(())
     }
 
-    fn read_snapshot_chunk(&self, _chunk: Option<&[u8]>) -> Result<Option<Vec<u8>>, Error> {
-        Ok(None)
+    fn read_snapshot_chunk(&self, _chunk: Option<&[u8]>) -> Result<Vec<u8>, Error> {
+        Ok(Vec::new())
     }
 
     fn write_snapshot_chunk(
@@ -60,7 +68,19 @@ impl StateMachine for NullStateMachine {
         index: LogIndex,
         _chunk_bytes: &[u8],
     ) -> Result<Option<Vec<u8>>, Error> {
-        self.snapshot_index = index;
+        self.index = index;
         Ok(None)
+    }
+
+    fn last_applied(&self) -> Result<LogIndex, Self::Error> {
+        Ok(self.index)
+    }
+
+    fn log(&self) -> &Self::Log {
+        todo!()
+    }
+
+    fn log_mut(&mut self) -> &mut Self::Log {
+        todo!()
     }
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -12,7 +12,7 @@ use raft_consensus::*;
 fn test_leader_transfer_error() {
     // Test the very first stage of init: election of a leader
     // after all nodes have started as followers
-    let mut cluster = TestCluster::new(3);
+    let mut cluster = TestCluster::new(3, false);
     for node in cluster.nodes.values() {
         assert_eq!(node.kind(), ConsensusState::Follower);
     }

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -33,6 +33,7 @@ impl Handler for TestHandler {
     /// Saves peer message to a vector
     fn send_peer_message(&mut self, id: ServerId, message: PeerMessage) {
         assert_ne!(self.cur, ServerId(u64::MAX));
+        trace!("peer message {:?} -> {:?}: {:?}", &self.cur, &id, &message);
         let q = self.peer_network.get_mut(&(self.cur, id)).unwrap();
         q.push_back(message);
     }
@@ -40,6 +41,12 @@ impl Handler for TestHandler {
     /// Saves client message to a vector
     fn send_client_message(&mut self, id: ClientId, message: ClientMessage) {
         assert_ne!(self.cur, ServerId(u64::MAX));
+        trace!(
+            "client message {:?} -> {:?}: {:?}",
+            &self.cur,
+            &id,
+            &message
+        );
         let q = self.client_network.get_mut(&(self.cur, id)).unwrap();
         q.push_back(message);
     }

--- a/tests/hash_machine.rs
+++ b/tests/hash_machine.rs
@@ -1,6 +1,8 @@
-use raft_consensus::state_machine::{self, SnapshotInfo, StateMachine};
+use raft_consensus::persistent_log::{Log, LogEntry, LogEntryData};
+use raft_consensus::state_machine::{SnapshotInfo, StateMachine};
 use raft_consensus::LogIndex;
 use std::hash::Hasher;
+
 use std::{collections::hash_map::DefaultHasher, fmt::Debug};
 
 use thiserror::Error as ThisError;
@@ -8,32 +10,30 @@ use thiserror::Error as ThisError;
 #[derive(ThisError, Debug)]
 #[error("Hash machine error")]
 pub enum Error {
-    HashMachineError,
+    HashMachineError(&'static str),
 }
 
 /// A state machine which hashes an incoming request with it's current state on apply.
 /// On query it hashes it's own state then adds the query above withtout modifying state itself
-/// Snapshot is a copy of a hash at the specific index split into 8 1-byte chunks
+/// Snapshot is a copy of a hash at the specific index split into 8 1-byte chunks with chunked flag
+/// of just a 8-byte arrays/vectors otherwise
+///
+/// In chunked mode the simpliest scheme is used for chunk/request:
+/// chunk: first byte is the number of chunk being sent, second byte is the chunk value
+/// requess: single byte requesting the next chunk
 #[derive(Clone)]
-pub struct HashMachine {
-    hash: u64,
-    current_snapshot: [u8; 8],
-    pending_snapshot: [u8; 8],
+pub struct HashMachine<L: Log> {
+    pub hash: u64,
+    pub current_snapshot: [u8; 8],
+    pub pending_snapshot: [u8; 8],
     hasher: DefaultHasher,
-    index: LogIndex,
-    chunked: bool,
+    pub index: LogIndex,
+    pub chunked: bool,
+    log: L,
 }
 
-impl PartialEq for HashMachine {
-    fn eq(&self, other: &Self) -> bool {
-        self.hash == other.hash
-    }
-}
-
-impl Eq for HashMachine {}
-
-impl HashMachine {
-    pub fn new(chunked: bool) -> Self {
+impl<L: Log> HashMachine<L> {
+    pub fn new(log: L, chunked: bool) -> Self {
         Self {
             hash: 0,
             current_snapshot: [0u8; 8],
@@ -41,43 +41,52 @@ impl HashMachine {
             hasher: DefaultHasher::new(),
             index: LogIndex(0),
             chunked,
+            log,
         }
     }
 }
 
-impl Debug for HashMachine {
+impl<L: Log> Debug for HashMachine<L> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(&self.hash, f)
     }
 }
 
-impl StateMachine for HashMachine {
+impl<L: Log> StateMachine for HashMachine<L> {
     type Error = Error;
+    type Log = L;
 
-    fn apply(&mut self, command: &[u8], results_required: bool) -> Result<Vec<u8>, Error> {
-        for byte in command {
-            self.hasher.write_u8(*byte);
-        }
+    fn apply(&mut self, index: LogIndex, results_required: bool) -> Result<Option<Vec<u8>>, Error> {
+        let mut entry = LogEntry::default();
+        self.log.read_entry(index, &mut entry);
+        if let LogEntryData::Proposal(command, _) = entry.data {
+            for byte in command {
+                self.hasher.write_u8(byte);
+            }
 
-        self.hash = self.hasher.finish();
-        if results_required {
-            Ok((&self.hash.to_le_bytes()[..]).to_vec())
+            self.hash = self.hasher.finish();
+            if results_required {
+                Ok(Some((&self.hash.to_le_bytes()[..]).to_vec()))
+            } else {
+                Ok(Some(Vec::new()))
+            }
         } else {
-            Ok(Vec::new())
+            Err(Error::HashMachineError(
+                "state machine can only apply proposals",
+            ))
         }
     }
 
     fn query(&self, query: &[u8]) -> Result<Vec<u8>, Error> {
-        let mut hasher = DefaultHasher::new();
-        hasher.write_u64(self.hash);
+        let mut hasher = self.hasher.clone();
         for byte in query {
             hasher.write_u8(*byte);
         }
-        (&hasher.finish().to_le_bytes()[..]).to_vec()
+        Ok((&hasher.finish().to_le_bytes()[..]).to_vec())
     }
 
     fn snapshot_info(&self) -> Result<Option<SnapshotInfo>, Self::Error> {
-        if self.hash == 0 {
+        if self.current_snapshot == [0; 8] {
             Ok(None)
         } else {
             Ok(Some(SnapshotInfo {
@@ -89,27 +98,65 @@ impl StateMachine for HashMachine {
 
     fn take_snapshot(&mut self, index: LogIndex) -> Result<(), Self::Error> {
         self.index = index;
-        let mut hasher = DefaultHasher::new();
-        hasher.write_u64(self.hash);
-        self.snapshot = hasher.finish();
+        self.current_snapshot = self.hash.to_le_bytes();
         Ok(())
     }
 
-    fn read_snapshot_chunk(&self, query: Option<&[u8]>) -> Result<Option<Vec<u8>>, Self::Error> {
+    fn read_snapshot_chunk(&self, query: Option<&[u8]>) -> Result<Vec<u8>, Self::Error> {
         if self.index == LogIndex(0) {
-            Ok(None)
-        } else if query == None {
-            Ok(Some((self.hash.to_le_bytes()[..]).to_vec()))
+            return Err(Error::HashMachineError("snapshot expected"));
+        };
+        if self.chunked {
+            if let Some(query) = query {
+                let chunk = query[0] as usize;
+                return Ok(vec![chunk as u8, self.current_snapshot[chunk]]);
+            } else {
+                return Ok(vec![0, self.current_snapshot[0]]);
+            }
         } else {
-            Ok(None)
+            if query == None {
+                return Ok(self.current_snapshot[..].to_vec());
+            } else {
+                Err(Error::HashMachineError("unexpected chunk request"))
+            }
         }
     }
 
     fn write_snapshot_chunk(
         &mut self,
-        index: raft_consensus::LogIndex,
+        index: LogIndex,
         chunk_bytes: &[u8],
     ) -> Result<Option<Vec<u8>>, Self::Error> {
+        // in this test implementation we consider all hash_machines initiated
+        // using the same `chunked` flag, but real impls could add it to return values
+        if self.chunked {
+            let chunk = chunk_bytes[0] as usize;
+            self.pending_snapshot[chunk] = chunk_bytes[1];
+            if chunk == 7 {
+                // 7th chunk is the last one
+                self.current_snapshot = self.pending_snapshot;
+                Ok(None)
+            } else {
+                Ok(Some(vec![chunk as u8 + 1u8]))
+            }
+        } else {
+            for i in 0..7 {
+                self.current_snapshot[i] = chunk_bytes[i];
+            }
+            self.hash = u64::from_le_bytes(self.current_snapshot);
+            Ok(None)
+        }
+    }
+
+    fn log(&self) -> &Self::Log {
+        todo!()
+    }
+
+    fn log_mut(&mut self) -> &mut Self::Log {
+        todo!()
+    }
+
+    fn last_applied(&self) -> Result<LogIndex, Self::Error> {
         todo!()
     }
 }


### PR DESCRIPTION
Implementing persistent log API inside of the state machine API opens a way for some optimizations, mainly for avoiding of copying data between log and state machine implementations.